### PR TITLE
Wandb miners info [In sequence of PR #7]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/openminers/base/miner.py
+++ b/openminers/base/miner.py
@@ -80,7 +80,7 @@ class BaseMiner(ABC):
             self.subtensor = subtensor or bt.subtensor(self.config)
 
         # Instantiate metagraph.
-        self.metagraph = self.subtensor.metagraph(self.config.netuid, sync=False)
+        self.metagraph = self.subtensor.metagraph(self.config.netuid)
         self.metagraph.sync(lite = True, subtensor=self.subtensor)
 
         # Instantiate wallet.
@@ -93,15 +93,16 @@ class BaseMiner(ABC):
 
         # Init wandb.
         if self.config.wandb.on:
-            wandb.init(
+            tags = [self.wallet.hotkey.ss58_address, f'netuid_{self.config.netuid}']
+            self.wandb_run = wandb.init(
                 project=self.config.wandb.project_name,
                 entity=self.config.wandb.entity,
                 config=self.config,
                 mode="online" if self.config.wandb.on else "offline",
                 dir=self.config.miner.full_path,
                 magic=True,
+                tags=tags,
             )
-
         # Instantiate runners.
         self.should_exit: bool = False
         self.is_running: bool = False

--- a/openminers/text_to_text/openai/README.md
+++ b/openminers/text_to_text/openai/README.md
@@ -10,7 +10,14 @@ This repository contains a Bittensor Miner that uses OpenAI's GPT-3.5-turbo mode
 
 1. Clone the repository
 2. Install the required packages with `pip install -r requirements.txt`
-3. Set your OpenAI API key in the `api_key` argument when running the script
+3. Ensure that you have your OpenAI key in your os environment variable
+```bash
+# Sets your openai key in os envs variable
+export OPENAI_API_KEY='your_openai_key_here'
+
+# Verifies if openai key is set correctly
+echo $OPENAI_API_KEY
+```
 
 For more configuration options related to the wallet, axon, subtensor, logging, and metagraph, please refer to the Bittensor documentation.
 
@@ -20,12 +27,13 @@ To run the OpenAI Bittensor Miner with default settings, use the following comma
 
 ```
 python3 -m pip install -r openminers/text_to_text/miner/openai/requirements.txt 
-python3 openminers/text_to_text/miner/openai/miner.py --openai.api_key <your OpenAI api_key>
+export OPENAI_API_KEY='sk-yourkey'
+python3 openminers/text_to_text/miner/openai/miner.py
 ```
 
 # Full Usage
 ```
-usage: miner.py [-h] [--openai.api_key OPENAI.API_KEY] [--openai.suffix OPENAI.SUFFIX] [--openai.max_tokens OPENAI.MAX_TOKENS]
+usage: miner.py [-h] [--openai.suffix OPENAI.SUFFIX] [--openai.max_tokens OPENAI.MAX_TOKENS]
                  [--openai.temperature OPENAI.TEMPERATURE] [--openai.top_p OPENAI.TOP_P] [--openai.n OPENAI.N]
                  [--openai.presence_penalty OPENAI.PRESENCE_PENALTY] [--openai.frequency_penalty OPENAI.FREQUENCY_PENALTY]
                  [--openai.model_name OPENAI.MODEL_NAME] [--netuid NETUID] [--miner.name NEURON.NAME]
@@ -47,9 +55,7 @@ usage: miner.py [-h] [--openai.api_key OPENAI.API_KEY] [--openai.suffix OPENAI.S
                  [--logging.logging_dir LOGGING.LOGGING_DIR] [--metagraph._mock] [--config CONFIG] [--strict]
 
 optional arguments:
-  -h, --help            show this help message and exit
-  --openai.api_key OPENAI.API_KEY
-                        openai api key
+  -h, --help            show this help message and exit  
   --openai.suffix OPENAI.SUFFIX
                         The suffix that comes after a completion of inserted text.
   --openai.max_tokens OPENAI.MAX_TOKENS

--- a/openminers/text_to_text/openai/miner.py
+++ b/openminers/text_to_text/openai/miner.py
@@ -87,7 +87,7 @@ class OpenAIMiner(openminers.BasePromptingMiner):
             raise ValueError(
                 "OpenAI API key is None: the miner requires an `OPENAI_API_KEY` defined in the environment variables or as an direct argument into the constructor."
             )
-        self.wandb_run.tags.append("openai_miner")
+        self.wandb_run.tags = self.wandb_run.tags + ("openai_miner",)
         openai.api_key = api_key
 
     def forward(self, messages: List[Dict[str, str]]) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tqdm==4.64.1
 datasets==2.12.0
 openai==0.27.8
 sentencepiece==0.1.99
+deepspeed==0.9.5


### PR DESCRIPTION
**NOTE: REVIEW AFTER #7 IS MERGED**

- fixes metagraph instantiation
- adds hotkey and netuid tags for wandb runs
- alters approach of handling open AI key*
 
The initial `python miner.py` command and its args that starts the application and the config are logged in wandb, making the openai key exposed in every run, opening a security breach for resources exploitation.  The adopted approach gets the openai key from the environment variables. 

I thought about implementing a yaml file config for that but I thought it could be overkill, but I believe it’s a very interesting approach. Let me know your thoughts if you have any preference on the approach.