### PR TITLE
Initial prompt-caching mechanism

### DIFF
--- a/openminers/base/blacklist.py
+++ b/openminers/base/blacklist.py
@@ -14,10 +14,36 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-
+import json
 import wandb
+import hashlib
 import bittensor as bt
-from typing import List, Dict, Union, Tuple, Callable
+from typing import Union, Tuple, Callable
+
+
+def is_prompt_in_cache(self, forward_call: "bt.TextPromptingForwardCall") -> bool:
+    # Hashes prompt
+    # Note: Could be improved using a similarity check
+    prompt = json.dumps(list(forward_call.messages))
+    prompt_key = hashlib.sha256(prompt.encode()).hexdigest()
+    current_block = self.metagraph.block
+
+    # Sanitize cache by removing old entries according to block span
+    keys_to_remove = []
+    for key, (_, block) in self.prompt_cache.items():
+        if block + self.config.miner.blacklist.prompt_cache_block_span < current_block:
+            keys_to_remove.append(key)
+
+    for key in keys_to_remove:
+        del self.prompt_cache[key]
+
+    # Check if prompt is in cache, if not add it
+    if prompt_key in self.prompt_cache:
+        return True
+    else:
+        caller_hotkey = forward_call.src_hotkey
+        self.prompt_cache[prompt_key] = (caller_hotkey, current_block)
+        return False
 
 
 def default_blacklist(
@@ -55,14 +81,10 @@ def default_blacklist(
     ):
         return True, "validator permit required"
 
-    # Get the uid stake amount.
-    stake_amount = self.metagraph.S[uid].item()
+    if is_prompt_in_cache(self, forward_call):
+        return True, "prompt already sent recently"
 
-    # Check if the user has enough stake.
-    if stake_amount < self.config.miner.blacklist.minimum_stake_requirement:
-        return True, "hotkey does not have enough stake"
-
-    # Other wise the user is not blacklisted.
+    # Otherwise the user is not blacklisted.
     return False, "passed blacklist"
 
 
@@ -71,7 +93,7 @@ def blacklist(
 ) -> Union[Tuple[bool, str], bool]:
     bt.logging.trace("run blacklist function")
 
-    # First check to see if the black list function is ovveridden by the subclass.
+    # First check to see if the black list function is overridden by the subclass.
     does_blacklist = None
     reason = None
     try:

--- a/openminers/base/config.py
+++ b/openminers/base/config.py
@@ -81,6 +81,12 @@ def add_args(cls, parser: argparse.ArgumentParser):
         help="Minimum stake requirement",
         default=0.0,
     )
+    parser.add_argument(
+        "--miner.blacklist.prompt_cache_block_span",
+        type=int,
+        help="Amount of blocks to keep a prompt in cache",
+        default=50,
+    )
 
     # Priority.
     parser.add_argument(

--- a/openminers/base/miner.py
+++ b/openminers/base/miner.py
@@ -70,6 +70,9 @@ class BaseMiner(ABC):
         self.config.merge(super_config)
         check_config(BaseMiner, self.config)
 
+        # Instantiate prompt cache where key is the encoded prompt and value is a tuple of hotkey and block
+        self.prompt_cache: Dict[str, Tuple[str, int]] = {}
+
         # Instantiate logging.
         bt.logging(config=self.config, logging_dir=self.config.miner.full_path)
 

--- a/openminers/text_to_text/openai/miner.py
+++ b/openminers/text_to_text/openai/miner.py
@@ -87,7 +87,8 @@ class OpenAIMiner(openminers.BasePromptingMiner):
             raise ValueError(
                 "OpenAI API key is None: the miner requires an `OPENAI_API_KEY` defined in the environment variables or as an direct argument into the constructor."
             )
-        self.wandb_run.tags = self.wandb_run.tags + ("openai_miner",)
+        if self.config.wandb.on:
+            self.wandb_run.tags = self.wandb_run.tags + ("openai_miner",)
         openai.api_key = api_key
 
     def forward(self, messages: List[Dict[str, str]]) -> str:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+# The MIT License (MIT)
+# Copyright © 2021 Yuma Rao
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.

--- a/tests/test_blacklist.py
+++ b/tests/test_blacklist.py
@@ -1,0 +1,123 @@
+import json
+import hashlib
+import unittest
+from unittest.mock import MagicMock
+from openminers.base.blacklist import is_prompt_in_cache
+
+class BlacklistTestCase(unittest.TestCase):
+    def test_sanitize_cache(self):
+        """ Test if old entries are removed according to block span """
+        # Arrange
+        messages =  ["Message from hotkey1"]
+        key_to_delete =  hashlib.sha256(json.dumps(messages).encode()).hexdigest()
+
+        mock_prompt_cache = {
+            key_to_delete: ('hotkey1', 1),
+        }
+        prompt_cache_block_span = 1
+        current_block = 3
+
+        mock_self = MagicMock()
+        mock_self.prompt_cache = mock_prompt_cache.copy()
+        mock_self.config.miner.blacklist.prompt_cache_block_span = prompt_cache_block_span
+        mock_self.metagraph.block = current_block
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = "hotkey1"
+        mock_forward_call.messages = messages
+
+        # Act
+        should_blacklist = is_prompt_in_cache(mock_self, mock_forward_call)
+
+        # Assert
+        assert should_blacklist is True
+        assert len(mock_self.prompt_cache) == len(mock_prompt_cache) - 1
+
+    def test_sanitize_cache_no_entries_removed(self):
+        """ Test if entries are not removed according to block span """
+        # Arrange
+        messages = ["Message from hotkey1"]
+        prompt_key = hashlib.sha256(json.dumps(messages).encode()).hexdigest()
+
+        mock_prompt_cache = {
+            prompt_key: ('hotkey1', 3),
+        }
+        prompt_cache_block_span = 1
+        current_block = 3
+
+        mock_self = MagicMock()
+        mock_self.prompt_cache = mock_prompt_cache.copy()
+        mock_self.config.miner.blacklist.prompt_cache_block_span = prompt_cache_block_span
+        mock_self.metagraph.block = current_block
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = "hotkey1"
+        mock_forward_call.messages = messages
+
+        # Act
+        should_blacklist = is_prompt_in_cache(mock_self, mock_forward_call)
+
+        # Assert
+        assert should_blacklist is True
+        assert len(mock_self.prompt_cache) == len(mock_prompt_cache)
+
+
+    def test_existing_prompt_in_cache(self):
+        """ Test if repeated entries are blacklisted"""
+        # Arrange
+        messages = ["Message from hotkey1"]
+        prompt_key = hashlib.sha256(json.dumps(messages).encode()).hexdigest()
+
+        mock_prompt_cache = {
+            prompt_key: ('hotkey1', 1),
+        }
+        prompt_cache_block_span = 1
+        current_block = 1
+
+        mock_self = MagicMock()
+        mock_self.prompt_cache = mock_prompt_cache.copy()
+        mock_self.config.miner.blacklist.prompt_cache_block_span = prompt_cache_block_span
+        mock_self.metagraph.block = current_block
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = "hotkey1"
+        mock_forward_call.messages = messages
+
+        # Act
+        should_blacklist = is_prompt_in_cache(mock_self, mock_forward_call)
+
+        # Assert
+        assert should_blacklist is True
+        assert mock_self.prompt_cache == mock_prompt_cache
+
+
+    def test_new_prompt_not_in_cache(self):
+        """ Test if new entries are not blacklisted and added correctly to cache """
+        # Arrange
+        messages = ["New prompt from hotkey1"]
+        expected_prompt_key = hashlib.sha256(json.dumps(messages).encode()).hexdigest()
+
+        mock_prompt_cache = {}
+        prompt_cache_block_span = 1
+        current_block = 1
+
+        mock_self = MagicMock()
+        mock_self.prompt_cache = mock_prompt_cache.copy()
+        mock_self.config.miner.blacklist.prompt_cache_block_span = prompt_cache_block_span
+        mock_self.metagraph.block = current_block
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = "hotkey1"
+        mock_forward_call.messages = messages
+
+        # Act
+        should_blacklist = is_prompt_in_cache(mock_self, mock_forward_call)
+
+        # Assert
+        assert should_blacklist is False
+        assert mock_self.prompt_cache[expected_prompt_key] == ('hotkey1', current_block)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- adds simple prompt-hash caching mechanism on blacklist pipeline
- adds new `--miner.blacklist.prompt_cache_block_span` param to regulate caching sanitization
- corrects wandb condition for logging tags on openai miner

The approach adopted for caching was a simple hashing lookup table composed by 

`{ hashed_prompt : [ hotkey, block ] }` 

where the hashed prompt is the sha256 of the received prompt. 

This can certainly be evolved to a more sophisticated verification, such as calculating the cosine similarity for simple embeddings (like sklearn tfidf) or more robust embeddings.

It’s worth highlighting though that anything we introduce here will sum up to the latency of the miners response, as this verification would happen before the process of every message.

Wandb run with implemented changes:
https://wandb.ai/opentensor-dev/openminers/runs/kd6zln41/