### PR TITLE
Priority update

### DIFF
--- a/openminers/base/blacklist.py
+++ b/openminers/base/blacklist.py
@@ -75,8 +75,8 @@ def default_blacklist(
 
     # Check if the key has validator permit
     if (
+        self.config.miner.blacklist.force_validator_permit and
         not self.metagraph.validator_permit[uid]
-        and self.config.miner.blacklist.force_validator_permit
     ):
         return True, "validator permit required"
 

--- a/openminers/base/blacklist.py
+++ b/openminers/base/blacklist.py
@@ -89,10 +89,10 @@ def default_blacklist(
         return True, "prompt already sent recently"
 
     # request period
-    if forward_call.src_hotkey in self.synapse.request_timestamps:
-        period = time.time() - self.synapse.request_timestamps[forward_call.src_hotkey][0]
+    if forward_call.src_hotkey in self.request_timestamps:
+        period = time.time() - self.request_timestamps[forward_call.src_hotkey][0]
         if period < self.config.miner.blacklist.min_request_period * 60:
-            return True, f"{forward_call.src_hotkey} request frequency exceeded {len(self.synapse.request_timestamps[forward_call.src_hotkey])} requests in {self.config.miner.blacklist.min_request_period} minutes."
+            return True, f"{forward_call.src_hotkey} request frequency exceeded {len(self.request_timestamps[forward_call.src_hotkey])} requests in {self.config.miner.blacklist.min_request_period} minutes."
 
     # Otherwise the user is not blacklisted.
     return False, "passed blacklist"

--- a/openminers/base/config.py
+++ b/openminers/base/config.py
@@ -86,8 +86,14 @@ def add_args(cls, parser: argparse.ArgumentParser):
         type=int,
         help="Amount of blocks to keep a prompt in cache",
         default=50,
+    ) 
+    parser.add_argument(
+        "--miner.blacklist.min_request_period",
+        type=int,
+        help="Time period (in minute) to serve a maximum of 50 requests for each hotkey",
+        default=30,
     )
-
+    
     # Priority.
     parser.add_argument(
         "--miner.priority.default",
@@ -97,6 +103,12 @@ def add_args(cls, parser: argparse.ArgumentParser):
     )
     parser.add_argument(
         "--miner.priority.use_s", type=float, help="A multiplier", default=0.0
+    )
+    parser.add_argument(
+        "--miner.priority.time_stake_multiplicate",
+        type=int,
+        help="Time (in minute) it takes to make the stake twice more important in the priority queue",
+        default=10,
     )
 
     # Switches.

--- a/openminers/base/config.py
+++ b/openminers/base/config.py
@@ -110,7 +110,12 @@ def add_args(cls, parser: argparse.ArgumentParser):
         help="Time (in minute) it takes to make the stake twice more important in the priority queue",
         default=10,
     )
-
+    parser.add_argument(
+        "--miner.priority.max_len_request_timestamps",
+        type=int,
+        help="Maximum number of historic request timestamps to record",
+        default=50,
+    )
     # Switches.
     parser.add_argument(
         "--miner.no_set_weights",

--- a/openminers/base/config.py
+++ b/openminers/base/config.py
@@ -111,9 +111,9 @@ def add_args(cls, parser: argparse.ArgumentParser):
         default=10,
     )
     parser.add_argument(
-        "--miner.priority.max_len_request_timestamps",
+        "--miner.priority.len_request_timestamps",
         type=int,
-        help="Maximum number of historic request timestamps to record",
+        help="Number of historic request timestamps to record",
         default=50,
     )
     # Switches.

--- a/openminers/base/miner.py
+++ b/openminers/base/miner.py
@@ -76,6 +76,17 @@ class BaseMiner(ABC):
         # Instantiate logging.
         bt.logging(config=self.config, logging_dir=self.config.miner.full_path)
 
+        # Warn if blacklist checking is turned off.
+        if (
+            not self.config.miner.blacklist.force_validator_permit
+            or self.config.miner.blacklist.allow_non_registered
+        ):
+            bt.logging.warning(
+                "Blacklist protections are disabled! "
+                f"Force Validator Permit: {self.config.miner.blacklist.force_validator_permit}, "
+                f"Allow Non-Registered: {self.config.miner.blacklist.allow_non_registered}"
+            )
+
         # Instantiate subtensor.
         if self.config.miner.mock_subtensor:
             self.subtensor = subtensor or MockSubtensor(self.config)

--- a/openminers/base/miner.py
+++ b/openminers/base/miner.py
@@ -111,6 +111,8 @@ class BaseMiner(ABC):
         self.is_running: bool = False
         self.thread: threading.Thread = None
 
+        self.request_timestamps = {}
+
     def run(self):
         run(self)
 

--- a/openminers/base/priority.py
+++ b/openminers/base/priority.py
@@ -21,7 +21,7 @@ from typing import List, Dict, Union, Tuple, Callable
 import time
 
 def record_request_timestamps(self, forward_call: "bt.TextPromptingForwardCall"):
-    timestamp_length = self.config.miner.priority.max_len_request_timestamps
+    timestamp_length = self.config.miner.priority.len_request_timestamps
     if forward_call.src_hotkey not in self.request_timestamps:
         self.request_timestamps[forward_call.src_hotkey] = [0] * timestamp_length
     

--- a/openminers/base/priority.py
+++ b/openminers/base/priority.py
@@ -18,7 +18,7 @@
 import wandb
 import bittensor as bt
 from typing import List, Dict, Union, Tuple, Callable
-
+import time
 
 def default_priority(self, forward_call: "bt.TextPromptingForwardCall") -> float:
     # Check if the key is registered.
@@ -33,7 +33,16 @@ def default_priority(self, forward_call: "bt.TextPromptingForwardCall") -> float
     # If the user is registered, it has a UID.
     uid = self.metagraph.hotkeys.index(forward_call.src_hotkey)
     stake_amount = self.metagraph.S[uid].item()
-    return stake_amount
+    
+    # request period
+    if forward_call.src_hotkey in self.synapse.request_timestamps:
+        period = (time.time() - self.synapse.request_timestamps[forward_call.src_hotkey][-10]) 
+    else:
+        period = time.time()
+
+    period /= (self.config.miner.priority.time_stake_multiplicate * 60) 
+
+    return max(period, 1) * stake_amount
 
 
 def priority(

--- a/openminers/base/run.py
+++ b/openminers/base/run.py
@@ -65,6 +65,10 @@ def run(self):
         # --- Update the metagraph with the latest network state.
         self.last_epoch_block = self.subtensor.get_current_block()
         self.metagraph.sync(lite=False, subtensor=self.subtensor)
+        for hotkey in self.request_timestamps:
+            if hotkey not in self.metagraph.hotkeys:
+                self.request_timestamps.pop(hotkey)
+
         self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
 
         # --- Log performance.

--- a/tests/test_blacklist.py
+++ b/tests/test_blacklist.py
@@ -138,7 +138,7 @@ class BlacklistTestCase(unittest.TestCase):
     def test_request_timestamps_blacklist(self):
         hotkey_address = 'hotkey1'
         min_request_period = 30
-        max_len_request_timestamps = 50
+        len_request_timestamps = 50
 
         mock_self = MagicMock()
         mock_self.config.miner.blacklist.whitelist = []
@@ -148,7 +148,7 @@ class BlacklistTestCase(unittest.TestCase):
         mock_self.config.miner.blacklist.min_request_period = min_request_period
         mock_self.metagraph.hotkeys = [hotkey_address]
         mock_self.request_timestamps = {
-            hotkey_address: [time.time() - (min_request_period*60-1)] * max_len_request_timestamps
+            hotkey_address: [time.time() - (min_request_period*60-1)] * len_request_timestamps
         }
 
         mock_forward_call = MagicMock()
@@ -160,7 +160,7 @@ class BlacklistTestCase(unittest.TestCase):
 
         # Should not black list when period is longer 
         mock_self.request_timestamps = {
-            hotkey_address: [time.time() - (min_request_period*60)] * max_len_request_timestamps
+            hotkey_address: [time.time() - (min_request_period*60)] * len_request_timestamps
         }
         should_blacklist, blacklist_message = default_blacklist(mock_self, mock_forward_call) 
         assert should_blacklist == False

--- a/tests/test_blacklist.py
+++ b/tests/test_blacklist.py
@@ -1,8 +1,26 @@
+# The MIT License (MIT)
+# Copyright © 2023 Yuma Rao
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import time
 import json
 import hashlib
 import unittest
 from unittest.mock import MagicMock
-from openminers.base.blacklist import is_prompt_in_cache
+from openminers.base.blacklist import is_prompt_in_cache, default_blacklist
 
 class BlacklistTestCase(unittest.TestCase):
     def test_sanitize_cache(self):
@@ -116,6 +134,59 @@ class BlacklistTestCase(unittest.TestCase):
         # Assert
         assert should_blacklist is False
         assert mock_self.prompt_cache[expected_prompt_key] == ('hotkey1', current_block)
+
+    def test_request_timestamps_blacklist(self):
+        hotkey_address = 'hotkey1'
+        min_request_period = 30
+        max_len_request_timestamps = 50
+
+        mock_self = MagicMock()
+        mock_self.config.miner.blacklist.whitelist = []
+        mock_self.config.miner.blacklist.blacklist = []
+        mock_self.config.miner.blacklist.allow_non_registered = False
+        mock_self.config.miner.blacklist.force_validator_permit = False
+        mock_self.config.miner.blacklist.min_request_period = min_request_period
+        mock_self.metagraph.hotkeys = [hotkey_address]
+        mock_self.request_timestamps = {
+            hotkey_address: [time.time() - (min_request_period*60-1)] * max_len_request_timestamps
+        }
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = hotkey_address
+        mock_forward_call.messages = "message"
+
+        should_blacklist, blacklist_message = default_blacklist(mock_self, mock_forward_call) 
+        assert should_blacklist == True
+
+        # Should not black list when period is longer 
+        mock_self.request_timestamps = {
+            hotkey_address: [time.time() - (min_request_period*60)] * max_len_request_timestamps
+        }
+        should_blacklist, blacklist_message = default_blacklist(mock_self, mock_forward_call) 
+        assert should_blacklist == False
+
+    def test_request_timestamps_blacklist_empty_dictionary(self):
+        hotkey_address = 'hotkey1'
+        min_request_period = 30
+
+        mock_self = MagicMock()
+        mock_self.config.miner.blacklist.whitelist = []
+        mock_self.config.miner.blacklist.blacklist = []
+        mock_self.config.miner.blacklist.allow_non_registered = False
+        mock_self.config.miner.blacklist.force_validator_permit = False
+        mock_self.config.miner.blacklist.min_request_period = min_request_period
+        mock_self.metagraph.hotkeys = [hotkey_address]
+        mock_self.request_timestamps = {}
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = hotkey_address
+        mock_forward_call.messages = "message"
+
+        should_blacklist, blacklist_message = default_blacklist(mock_self, mock_forward_call) 
+        assert should_blacklist == False
+
+
+
 
 
 

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -23,10 +23,10 @@ from openminers.base.priority import record_request_timestamps, default_priority
 class PriorityTestCase(unittest.TestCase):
     def test_record_request_timestamps(self):
         hotkey_address = 'hotkey1'
-        max_len_request_timestamps = 20
+        len_request_timestamps = 20
 
         mock_self = MagicMock()
-        mock_self.config.miner.priority.max_len_request_timestamps = max_len_request_timestamps
+        mock_self.config.miner.priority.len_request_timestamps = len_request_timestamps
         mock_self.request_timestamps = {}
 
         mock_forward_call = MagicMock()
@@ -37,8 +37,8 @@ class PriorityTestCase(unittest.TestCase):
             mock_forward_call.start_time = i
             times.append(i)
             request_timestamps = record_request_timestamps(mock_self, mock_forward_call)
-            assert request_timestamps[hotkey_address] == [0]*(max_len_request_timestamps - i) + times
-            assert len(request_timestamps[hotkey_address]) == max_len_request_timestamps
+            assert request_timestamps[hotkey_address] == [0]*(len_request_timestamps - i) + times
+            assert len(request_timestamps[hotkey_address]) == len_request_timestamps
 
     def test_default_priority(self):
         hotkey_address = 'hotkey1'

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,0 +1,68 @@
+# The MIT License (MIT)
+# Copyright © 2023 Yuma Rao
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import torch
+import unittest
+from unittest.mock import MagicMock, patch
+from openminers.base.priority import record_request_timestamps, default_priority
+
+class PriorityTestCase(unittest.TestCase):
+    def test_record_request_timestamps(self):
+        hotkey_address = 'hotkey1'
+        max_len_request_timestamps = 20
+
+        mock_self = MagicMock()
+        mock_self.config.miner.priority.max_len_request_timestamps = max_len_request_timestamps
+        mock_self.request_timestamps = {}
+
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = hotkey_address
+
+        times = []
+        for i in range(1, 21):
+            mock_forward_call.start_time = i
+            times.append(i)
+            request_timestamps = record_request_timestamps(mock_self, mock_forward_call)
+            assert request_timestamps[hotkey_address] == [0]*(max_len_request_timestamps - i) + times
+            assert len(request_timestamps[hotkey_address]) == max_len_request_timestamps
+
+    def test_default_priority(self):
+        hotkey_address = 'hotkey1'
+        stake = 1
+        default_priority_value = 100
+        time_stake_multiplicate = 2
+
+        mock_self = MagicMock()
+        mock_self.metagraph.hotkeys = [hotkey_address]
+        mock_self.metagraph.S = [torch.tensor(stake)]
+        mock_self.config.miner.priority.time_stake_multiplicate = time_stake_multiplicate
+        mock_self.config.miner.priority.default = default_priority_value
+        
+        mock_forward_call = MagicMock()
+        mock_forward_call.src_hotkey = hotkey_address
+
+        # return default when request timestamp is empty 
+        mock_self.request_timestamps = {}
+        priority = default_priority(mock_self, mock_forward_call)
+        assert priority == default_priority_value 
+
+        # return priority when request timestamp is not empty 
+        mock_self.request_timestamps = {hotkey_address: [0]*10}
+        for minute_passed in range(1,20):
+            with patch('time.time', MagicMock(return_value=minute_passed*60)):
+                priority = default_priority(mock_self, mock_forward_call)
+                assert priority == max(minute_passed/time_stake_multiplicate, 1)*stake 


### PR DESCRIPTION
**=== New Priority Feature===**
**config**
- miner.priority.max_len_request_timestamps: The number of timestamps that would be recorded 
- miner.priority.time_stake_multiplicate: Time (in minute) it takes to make the stake twice more important in the priority queue

**description**
- priority = stake * time_passed /  time_stake_multiplicate

**=== New Blacklist Feature ===**
**config**
- miner.blacklist.min_request_period: Time period (in minute) to serve a maximum of 50 requests for each hotkey

**description**
- blacklisted when time taken to serve 50 requests < min_request_period